### PR TITLE
feat(yandex-metrika): support runtime config

### DIFF
--- a/packages/yandex-metrika/README.md
+++ b/packages/yandex-metrika/README.md
@@ -10,8 +10,10 @@ This plugins automatically sends first page and route change events to yandex me
 You can set environment variable `NODE_ENV` to `production` for testing in dev mode.
 
 ## Setup
+
 - Add `@nuxtjs/yandex-metrika` dependency using yarn or npm to your project
 - Add `@nuxtjs/yandex-metrika` to `modules` section of `nuxt.config.js`
+
 ```js
 {
   modules: ['@nuxtjs/yandex-metrika'],
@@ -19,7 +21,9 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 ```
 
 ## Configure
-You can pass options directly in module declaration.
+
+You can pass options directly in module declaration:
+
 ```js
 {
   modules: [
@@ -28,37 +32,65 @@ You can pass options directly in module declaration.
       {
         id: 'XXXXXX',
         webvisor: true,
-        // clickmap:true,
-        // useCDN:false,
-        // trackLinks:true,
-        // accurateTrackBounce:true,
+        // clickmap: true,
+        // useCDN: false,
+        // trackLinks: true,
+        // accurateTrackBounce: true,
       }
-    ],
+    ]
   ]
 }
 ```
-Or you can specify `yandexMetrika` key.
+
+Or you can specify `yandexMetrika` key:
+
 ```js
 {
   modules: ['@nuxtjs/yandex-metrika'],
   yandexMetrika: {
     id: 'XXXXXX',
-    webvisor: true,
-    // clickmap:true,
-    // useCDN:false,
-    // trackLinks:true,
-    // accurateTrackBounce:true,
-  },
+    // ...
+  }
+}
+```
+
+In Nuxt 2.13+, you can also use public runtime config:
+
+```js
+{
+  modules: ['@nuxtjs/yandex-metrika'],
+  publicRuntimeConfig: {
+    yandexMetrika: {
+      id: process.env.YANDEX_METRIKA_ID,
+      // ...
+    }
+  }
 }
 ```
 
 ## Options
+
 For more information:
 - [Documetation for Ya.Metrika](https://yandex.com/support/metrica/code/counter-initialize.html)
 - [hit method](https://yandex.com/support/metrica/objects/hit.html)
 
 ### `id`
+
 - Required
+
+### `useRuntimeConfig`
+
+- Default: `yandexMetrika`
+
+Public runtime config key. Set to `false` to disable runtime configuration.
+
+### `useCDN`
+
+- Default: false
+
+Load metrika script from <https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js>.
+
+This option can not be provided via runtime config.
 
 ### `accurateTrackBounce`
 ### `childIframe`
@@ -71,11 +103,6 @@ For more information:
 ### `trackLinks`
 ### `trustedDomains`
 ### `type`
-### `useCDN`
 ### `ut`
 ### `webvisor`
 ### `triggerEvent`
-
-
-
-

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,7 +6,11 @@ module.exports = function yandexMetrika (moduleOptions) {
     return
   }
 
-  const options = { ...(moduleOptions || {}), ...(this.options.yandexMetrika || {}) }
+  const options = {
+    useRuntimeConfig: this.options.publicRuntimeConfig ? 'yandexMetrika' : undefined,
+    ...this.options.yandexMetrika,
+    ...moduleOptions
+  }
 
   const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js' // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
 
@@ -18,7 +22,6 @@ module.exports = function yandexMetrika (moduleOptions) {
     rel: 'preload',
     as: 'script'
   })
-
 
   // Register plugin
   this.addPlugin({ src: path.resolve(__dirname, 'plugin.js'), ssr: false, options })

--- a/packages/yandex-metrika/plugin.js
+++ b/packages/yandex-metrika/plugin.js
@@ -1,4 +1,11 @@
-export default ({ app: { router } }) => {
+export default ({ app: { router }, $config }) => {
+
+  const { useRuntimeConfig, metrikaUrl, ...options } = <%= JSON.stringify(options) %>
+  if ($config && useRuntimeConfig) {
+    Object.assign(options, $config[useRuntimeConfig])
+  }
+  const { id, ...metrikaOptions } = options
+
   let ready = false
 
   router.onReady(() => {
@@ -12,12 +19,12 @@ export default ({ app: { router } }) => {
       // Don't record a duplicate hit for the initial navigation.
       (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
         m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-      (window, document, "script", '<%= options.metrikaUrl %>', "ym")
+      (window, document, "script", metrikaUrl, "ym")
 
-      ym(<%= options.id %>, "init", <%= JSON.stringify(options) %>)
+      ym(id, "init", metrikaOptions)
     }
     router.afterEach((to, from) => {
-      ym(<%= options.id %>, 'hit', to.fullPath, {
+      ym(id, 'hit', to.fullPath, {
         referer: from.fullPath
         // TODO: pass title: <new page title>
         // This will need special handling because router.afterEach is called *before* DOM is updated.


### PR DESCRIPTION
1. Add runtime config support for yandex-metrika (pre-2.13 compatible).
2. General plugin refactoring, fix metrika `init` call sending all plugin options to Yandex.